### PR TITLE
Add: Add an organization wide issue template

### DIFF
--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Greenbone Community Forum
+    url: https://forum.greenbone.net/
+    about: Please ask questions here.

--- a/ISSUE_TEMPLATE/issue-report.md
+++ b/ISSUE_TEMPLATE/issue-report.md
@@ -1,0 +1,66 @@
+---
+name: Issue Report
+about: Report an issue
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+<!--
+If reporting an issue please try to provide the information asked below.
+
+Before reporting an issue please:
+
+1. Be aware that this is not a support forum. If your issue is rather a question
+   than a bug report, please use our community forum at
+   https://forum.greenbone.net/ instead.
+2. Make sure that you're using the latest published version
+3. Check the list of issues whether it isn't already reported.
+4. Read 1. again and if you still believe you found a software bug please
+   continue to file this issue. If you are in doubt use
+   https://forum.greenbone.net/ instead.
+
+Thanks for your help to keep the communication channels clean and consistent!
+-->
+
+### Expected behavior
+
+<!--
+  How did you expect the software to behave?
+  Please write down how the software should work in your opinion.
+-->
+
+### Actual behavior
+
+<!--
+  Did something go wrong?
+  Is something broken, or not behaving as you expected?
+  Is this really an bug? If in doubt please use
+  https://forum.greenbone.net/ instead.
+  Please attach screenshots if possible! They are extremely helpful for
+  diagnosing issues.
+-->
+
+### Steps to reproduce
+
+<!--
+  How would you describe your issue to someone who doesn’t know the software?
+  Try to write a sequence of steps that anybody can repeat to see the issue.
+-->
+
+1.
+2.
+3.
+
+### Installed version
+
+<!-- please report the installed version -->
+
+### Environment
+
+**Operating system:**
+
+<!-- e.g. paste output of `cat /etc/os-release` -->
+
+**Installation method / source:** (distribution packages, container, source installation)


### PR DESCRIPTION
## What

Add an organization wide issue template

## Why

Provide a generic issue template for all repos

## References

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates

DEVOPS-642


